### PR TITLE
Add 'fetchbyurn' script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+/config_test.log
+/config_test.o
+/config_test.c
+/config_test.h
+/config_test
+/config.h
+/src/bitter
+/src/config.h
+/src/lib/Makefile
+/src/lib/config.h
+/src/Makefile
+/src/**/*.o

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /config_test.h
 /config_test
 /config.h
+/repos.lst
 /src/bitter
 /src/config.h
 /src/lib/Makefile

--- a/fetchbyurn
+++ b/fetchbyurn
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+repos=()
+
+scriptname="$0"
+urn=""
+outfile=""
+bitter="$(dirname "$0")/src/bitter -q"
+
+#   0 = silent
+# 100 = errors
+# 150 = warnings
+# 200 = very chatty
+verbosity=100
+
+while [ $# -gt 0 ]
+do
+    key="$1"
+    case $key in
+	-repo)
+	    repos+=("$2")
+	    shift
+	    ;;
+	-v)
+	    verbosity=200
+	    ;;
+	-o)
+	    outfile="$2"
+	    shift
+	    ;;
+	*)
+	    urn="$1"
+    esac
+    shift
+done
+
+for defaultrepo in fs.marvin.nuke24.net toggh1.nuke24.net piccouch.appspot.com
+do
+    repos+=("$defaultrepo")
+done
+
+if [ -z "$urn" ]
+then
+    echo "$scriptname: Error: No URN specified" >&2
+    exit 1
+fi
+
+if [ -z "$outfile" ]
+then
+    echo "$scriptname: Error: No outfile (-o) specified" >&2
+    exit 1
+fi
+
+tempfile="$(dirname "$outfile")/.$(basename "$outfile").temp"
+
+# If the file already exists and matches, skip downloading!!!
+if [ -e "$outfile" ]
+then
+    actualurn="$($bitter "$outfile")"
+    if [ "$actualurn" == "$urn" ]
+    then
+	if [ "$verbosity" -ge 200 ] ; then 
+	    echo "$scriptname: $outfile already up-to-date" >&1
+	fi
+	exit 0
+    fi
+fi
+
+
+for repo in "${repos[@]}"
+do
+    dlurl="http://${repo}/uri-res/N2R?${urn}"
+    if curl -s -f -o "$tempfile" "$dlurl"
+    then
+	actualurn="$($bitter "$tempfile")"
+	if [ "${actualurn}" == "$urn" ]
+	then
+	    if [ "$verbosity" -ge 200 ] ; then echo "$scriptname: Successfully downloaded from $dlurl" >&2 ; fi
+	    mv "$tempfile" "$outfile"
+	    exit $?
+	else
+	    if [ "$verbosity" -ge 150 ] ; then echo "$scriptname: Hash mismatch: $dlurl = $actualurn" >&2 ; fi
+	fi
+    else
+	if [ "$verbosity" -ge 200 ] ; then echo "$scriptname: Failed to download from $dlurl" >&2 ; fi
+    fi
+done
+
+if [ "$verbosity" -ge 100 ] ; then 
+    echo "$scriptname: Failed to download $urn from any source" >&2
+fi
+exit 1

--- a/fetchbyurn
+++ b/fetchbyurn
@@ -34,11 +34,6 @@ do
     shift
 done
 
-for defaultrepo in fs.marvin.nuke24.net toggh1.nuke24.net piccouch.appspot.com
-do
-    repos+=("$defaultrepo")
-done
-
 if [ -z "$urn" ]
 then
     echo "$scriptname: Error: No URN specified" >&2
@@ -50,6 +45,18 @@ then
     echo "$scriptname: Error: No outfile (-o) specified" >&2
     exit 1
 fi
+
+defaultrepolistfiles=("$(dirname "$0")/repos.lst")
+for defaultrepolistfile in "${defaultrepolistfiles[@]}"
+do
+    if [ -e "$defaultrepolistfile" ]
+    then
+	for defaultrepo in $(cat "$defaultrepolistfile")
+	do
+	    repos+=("$defaultrepo")
+	done
+    fi
+done
 
 tempfile="$(dirname "$outfile")/.$(basename "$outfile").temp"
 

--- a/fetchbyurn
+++ b/fetchbyurn
@@ -16,7 +16,7 @@ verbosity=100
 while [ $# -gt 0 ]
 do
     key="$1"
-    case $key in
+    case "$key" in
 	-repo)
 	    repos+=("$2")
 	    shift
@@ -51,7 +51,8 @@ for defaultrepolistfile in "${defaultrepolistfiles[@]}"
 do
     if [ -e "$defaultrepolistfile" ]
     then
-	for defaultrepo in $(cat "$defaultrepolistfile")
+	if [ "$verbosity" -ge 200 ] ; then echo "$scriptname: Reading default repo list from $defaultrepolistfile" >&2 ; fi
+	for defaultrepo in $(grep -v '^#\|^$' "$defaultrepolistfile")
 	do
 	    repos+=("$defaultrepo")
 	done

--- a/repos.lst.example
+++ b/repos.lst.example
@@ -1,0 +1,4 @@
+harold.nuke24.net
+fs.marvin.nuke24.net
+toggh1.nuke24.net
+piccouch.appspot.com

--- a/repos.lst.example
+++ b/repos.lst.example
@@ -1,3 +1,6 @@
+# Repository list used by fetchbyurn;
+# Each line is expanded to http://<domain>/uri-res/N2R?<urn>
+
 harold.nuke24.net
 fs.marvin.nuke24.net
 toggh1.nuke24.net


### PR DESCRIPTION
Adds a script, ```fetchbyurn```, which, given a ```urn:bitprint:...``` URN, will attempt to download the file from multiple sources (URLs of the form ```http://${domain}/uri-res/N2R?${urn}```, using curl to download the files, and uses bitter to verify the bitprint hash.

Also I added a ```.gitignore```